### PR TITLE
fix randomBytes

### DIFF
--- a/src/Node/Crypto.purs
+++ b/src/Node/Crypto.purs
@@ -3,7 +3,7 @@ module Node.Crypto where
 import Prelude
 
 import Effect (Effect)
-import Node.Buffer (Buffer, fromString)
+import Node.Buffer (Buffer, fromString, toString)
 import Node.Crypto.Hash (Algorithm(..))
 import Node.Crypto.Hmac (createHmac, digest, update)
 import Node.Encoding (Encoding(..))
@@ -14,7 +14,7 @@ timingSafeEqualString :: String -> String -> Effect Boolean
 timingSafeEqualString x1 x2 = do
   a1 <- fromString x1 UTF8
   a2 <- fromString x2 UTF8
-  secret <- randomBytes 32
+  secret <- randomBytes 32 >>= toString UTF8
   b1 <- createHmac SHA256 secret >>= flip update a1 >>= digest
   b2 <- createHmac SHA256 secret >>= flip update a2 >>= digest
   conj (x1 == x2) <$> timingSafeEqual b1 b2
@@ -25,4 +25,4 @@ foreign import timingSafeEqual :: Buffer -> Buffer -> Effect Boolean
 
 
 
-foreign import randomBytes :: Int -> Effect String
+foreign import randomBytes :: Int -> Effect Buffer


### PR DESCRIPTION
https://nodejs.org/api/crypto.html#crypto_crypto_randombytes_size_callback

> Returns: <Buffer> if the callback function is not provided.

*This PR contains incompatible API changes.*