### PR TITLE
Add hash functions to compute on Node.Buffer

### DIFF
--- a/src/Node/Crypto/Hash.purs
+++ b/src/Node/Crypto/Hash.purs
@@ -2,7 +2,9 @@ module Node.Crypto.Hash
   ( Hash
   , Algorithm(..)
   , hex
+  , hexBuffer
   , base64
+  , base64Buffer
   , createHash
   , update
   , digest
@@ -33,11 +35,23 @@ hex
   -> Effect String
 hex alg str = hash alg str Hex
 
+hexBuffer
+  :: Algorithm
+  -> Buffer
+  -> Effect String
+hexBuffer alg buf = hashBuffer alg buf Hex
+
 base64
   :: Algorithm
   -> String
   -> Effect String
 base64 alg str = hash alg str Base64
+
+base64Buffer
+  :: Algorithm
+  -> Buffer
+  -> Effect String
+base64Buffer alg buf = hashBuffer alg buf Base64
 
 hash
   :: Algorithm
@@ -46,6 +60,14 @@ hash
   -> Effect String
 hash alg str enc = do
   buf <- fromString str UTF8
+  createHash alg >>= flip update buf >>= digest >>= toString enc
+
+hashBuffer
+  :: Algorithm
+  -> Buffer
+  -> Encoding
+  -> Effect String
+hashBuffer alg buf enc = do
   createHash alg >>= flip update buf >>= digest >>= toString enc
 
 createHash :: Algorithm -> Effect Hash

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,28 +3,35 @@ module Test.Main where
 import Prelude
 
 import Effect (Effect)
+import Node.Buffer as Buffer
 import Node.Crypto as Crypto
 import Node.Crypto.Cipher as Cipher
 import Node.Crypto.Decipher as Decipher
 import Node.Crypto.Hash as Hash
 import Node.Crypto.Hmac as Hmac
+import Node.Encoding(Encoding(..))
 import Test.Assert (assert)
 
 main :: Effect Unit
 main = do
   hexHash <- Hash.hex Hash.SHA512 password
+  buf <- Buffer.fromString password UTF8
+  hexBufferHash <- Hash.hexBuffer Hash.SHA512 buf
   hexHmac <- Hmac.hex Hash.SHA512 secret password
   hexCipher <- Cipher.hex Cipher.AES256 password identifier
   fromHexDecipher <- Decipher.fromHex Cipher.AES256 password hexCipher
   base64Hash <- Hash.base64 Hash.SHA512 password
+  base64BufferHash <- Hash.base64Buffer Hash.SHA512 buf
   base64Hmac <- Hmac.base64 Hash.SHA512 secret password
   base64Cipher <- Cipher.base64 Cipher.AES256 password identifier
   fromBase64Decipher <- Decipher.fromBase64 Cipher.AES256 password base64Cipher
   assert $ hexHash == "fd369c76561c41e90eaacef9e95dde1b92a402980b75d739da368ad427e2a5a01bc79e5a6fb46df001b8e21c94e702bfb47574271e4098150854e112bb9c9d1d"
+  assert $ hexBufferHash == "fd369c76561c41e90eaacef9e95dde1b92a402980b75d739da368ad427e2a5a01bc79e5a6fb46df001b8e21c94e702bfb47574271e4098150854e112bb9c9d1d"
   assert $ hexHmac == "64ca657263492b718984ab0a4a5a2a43288c35d9e15c6797f2597ce8e8440e862c5495cf852f4044e6caa9fe58bf0972153fcb827a5581d06e72b404126dbf05"
   assert $ hexCipher == "fa27b1b589a3c39576c9cecfe5071682815da543fbce75c4823a6be70f0e1777"
   assert $ fromHexDecipher == identifier
   assert $ base64Hash == "/TacdlYcQekOqs756V3eG5KkApgLddc52jaK1CfipaAbx55ab7Rt8AG44hyU5wK/tHV0Jx5AmBUIVOESu5ydHQ=="
+  assert $ base64BufferHash == "/TacdlYcQekOqs756V3eG5KkApgLddc52jaK1CfipaAbx55ab7Rt8AG44hyU5wK/tHV0Jx5AmBUIVOESu5ydHQ=="
   assert $ base64Hmac == "ZMplcmNJK3GJhKsKSloqQyiMNdnhXGeX8ll86OhEDoYsVJXPhS9ARObKqf5YvwlyFT/LgnpVgdBucrQEEm2/BQ=="
   assert $ base64Cipher == "+iextYmjw5V2yc7P5QcWgoFdpUP7znXEgjpr5w8OF3c="
   assert $ fromBase64Decipher == identifier


### PR DESCRIPTION
I needed to fix some subtle UTF-8 problems in my code, and needed to generate hashes from Node.Buffer types.  
I added hexBuffer and base64Buffer functions so as to not affect the current API.
There are two tests added as well.
