### PR TITLE
Algorithm newtype introduced in createHash for better type safety

### DIFF
--- a/src/Node/Crypto/Hash.purs
+++ b/src/Node/Crypto/Hash.purs
@@ -1,5 +1,6 @@
 module Node.Crypto.Hash
   ( Hash
+  , Algorithm(..)
   , createHash
   , update
   , digest
@@ -19,8 +20,10 @@ import Node.Buffer (Buffer)
 -- | ```
 foreign import data Hash :: Type
 
-createHash :: String -> Effect Hash
-createHash alg = runEffectFn1 createHashImpl alg
+newtype Algorithm = Algorithm String
+
+createHash :: Algorithm -> Effect Hash
+createHash (Algorithm alg) = runEffectFn1 createHashImpl alg
 
 update :: Buffer -> Hash -> Effect Hash
 update buf hash = runEffectFn2 updateImpl buf hash

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -21,7 +21,7 @@ main = runTest do
   test "hash" do
     result <- liftEffect do
       buf <- Buffer.fromString "dummy" UTF8
-      Hash.createHash "sha512" >>= Hash.update buf >>= Hash.digest >>= Buffer.toString Hex
+      Hash.createHash (Hash.Algorithm "sha512") >>= Hash.update buf >>= Hash.digest >>= Buffer.toString Hex
     Assert.equal "1692526aab84461a8aebcefddcba2b33fb5897ab180c53e8b345ae125484d0aaa35baf60487050be21ed8909a48eace93851bf139087ce1f7a87d97b6120a651" result
 
   test "hmac" do


### PR DESCRIPTION
Changed the type of `createHash` from `String -> Effect Hash` to `Algorithm -> Effect Hash`.

---

So far, `createHash` has accepted a `String` representing the hash algorithm. This is ambiguous and error-prone — it gives no clue that the string represents the algorithm name, not the input to be hashed. This can easily lead to misuse or confusion, for example:

    createHash "hello" -- mistakenly hashing "hello" instead of selecting the algorithm

This example will compile, but crash at runtime with:

    Uncaught Error: Digest method not supported

By introducing the `Algorithm` newtype:

    createHash (Algorithm "hello") -- clearly wrong: "hello" is not a valid algorithm

We make incorrect usage visibly suspicious. The newtype acts as a clue, encouraging the user to pause and consider what this string actually represents. It clarifies intent and helps prevent real-world runtime errors.